### PR TITLE
Get addresses from interface and lib function calls

### DIFF
--- a/app/src/helpers/getAbiIfReturnsAddress.ts
+++ b/app/src/helpers/getAbiIfReturnsAddress.ts
@@ -1,0 +1,34 @@
+import { Interface } from "ethers/lib/utils";
+import getContractInfo from "./getContractInfo"
+import getPrisma from "./getPrisma";
+
+export default async (address: string, chain: string, functionName: string) => {
+  await getContractInfo(address, chain);
+  const {abi} = await getPrisma().contract.findFirst({
+    where: {
+      address,
+      chain,
+    },
+    select: {
+      abi: true,
+    }
+  }) || {abi: null};
+  if (!abi) {
+    return null;
+  }
+  for (const [nameFull, func] of Object.entries((new Interface(abi)).functions)){
+    const name = nameFull.split('(')[0]
+    if (name !== functionName) {
+      continue;
+    }
+    const retTypes = func.outputs?.map(o => o.type);
+    if (retTypes?.length !== 1) {
+      return;
+    }
+    const retType = retTypes[0];
+    if (retType === 'address') {
+      return abi;
+    }
+  }
+  return;
+}

--- a/app/src/helpers/getContractAddresses.ts
+++ b/app/src/helpers/getContractAddresses.ts
@@ -2,6 +2,7 @@ import { Contract } from '@prisma/client';
 import { parse, visit } from '@solidity-parser/parser'
 import { ASTNode, BaseASTNode, VariableDeclaration } from '@solidity-parser/parser/dist/src/ast-types';
 import { AddressInfo } from '~/types'
+import loadContractLibraries from './loadContractLibraries';
 
 const isAddress = (val: string) => {
   return val.length === 42 && val.startsWith('0x')
@@ -30,8 +31,8 @@ function getFlatLocationInfo(node: ASTNode | BaseASTNode) {
 
 const getVariableId = (varName: string, node: ASTNode) => (`${varName} ${node.range ? node.range[0] : ''}`);
 
-export const getAddresses = (contractInfo: Contract) => {
-  const { contractName, contractPath, sourceCode, address } = contractInfo;
+export const getAddresses = async (contractInfo: Contract) => {
+  const { contractName, contractPath, sourceCode, address, chain } = contractInfo;
   const ast = getAst(sourceCode);
   const addresses: AddressInfo[] = [];
   // Number literals are added twice, so we skip every second one
@@ -191,5 +192,6 @@ export const getAddresses = (contractInfo: Contract) => {
       )
     }
   })
+  await loadContractLibraries(address, chain);
   return addresses;
 }

--- a/app/src/helpers/getContractAddresses.ts
+++ b/app/src/helpers/getContractAddresses.ts
@@ -449,7 +449,7 @@ export const getAddresses = async (contractInfo: Contract) => {
       address.address = await address.getAddress();
       resolvedAddressIdx.push(i);
     } catch (e) {
-      console.log(e)
+      console.error(e)
       return
     }
   }))

--- a/app/src/helpers/getContractAddresses.ts
+++ b/app/src/helpers/getContractAddresses.ts
@@ -60,10 +60,9 @@ export const getAddresses = async (contractInfo: Contract) => {
   const ast = getAst(sourceCode);
   const addresses: AddressInfo[] = [];
   // Number literals are added twice, so we skip every second one
-  let skipNextNumber = false;
   visit(ast, {
     NumberLiteral: (node, parent) => {
-      if (isAddress(node.number) && node.loc && !skipNextNumber) {
+      if (isAddress(node.number) && node.loc) {
         addresses.push(
           {
             contractPath,
@@ -80,7 +79,6 @@ export const getAddresses = async (contractInfo: Contract) => {
           }
         )
       }
-      skipNextNumber = !skipNextNumber;
     }
   })
   const discoveredVariables: Record<string, string> = {};

--- a/app/src/helpers/getContractAddresses.ts
+++ b/app/src/helpers/getContractAddresses.ts
@@ -268,8 +268,6 @@ export const getAddresses = async (contractInfo: Contract) => {
           return
         }
         const addressToCall = discoveredStateVars[matchingName] || discoveredVariables[matchingName] || undefined;
-        console.log(discoveredStateVars, discoveredVariables)
-        console.log('addressToCall', addressToCall)
         if (!addressToCall) {
           return
         }

--- a/app/src/helpers/getProvider.ts
+++ b/app/src/helpers/getProvider.ts
@@ -1,0 +1,10 @@
+import {getDefaultProvider} from 'ethers'
+const CHAIN_IDS: Record<string, string> = {
+  mainnet: 'homestead',
+  goerli: 'goerli',
+  sepolia: 'sepolia',
+  optimism: 'optimism',
+}
+export default (chain: string) => {
+  return getDefaultProvider(CHAIN_IDS[chain])
+}

--- a/app/src/helpers/getProvider.ts
+++ b/app/src/helpers/getProvider.ts
@@ -4,6 +4,7 @@ const CHAIN_IDS: Record<string, string> = {
   goerli: 'goerli',
   sepolia: 'sepolia',
   optimism: 'optimism',
+  mode: 'https://sepolia.mode.network/',
 }
 export default (chain: string) => {
   return getDefaultProvider(CHAIN_IDS[chain])

--- a/app/src/helpers/loadContractLibraries.ts
+++ b/app/src/helpers/loadContractLibraries.ts
@@ -1,0 +1,23 @@
+import getContractInfo from "./getContractInfo";
+import getPrisma from "./getPrisma";
+
+export default async function loadContractLibraries(address: string, chain: string) {
+  await getContractInfo(address, chain);
+  const contract = await getPrisma().contract.findFirst({ where: {
+    address,
+    chain
+  }})
+  if (!contract) throw new Error("Contract not found");
+  if (contract.library === '') return {};
+  const libraries = contract.library.split(';')
+  const ret = Object.fromEntries(libraries.map(l => {
+    const [key, val] = l.split(':');
+    return [key, `0x${val}`]
+  }));
+  await Promise.all(
+    Object.values(ret).map(async (v) => {
+      return loadContractLibraries(v, chain)
+    })
+  )
+  return ret;
+}

--- a/app/src/pages/api/linking/[chain]/[address].ts
+++ b/app/src/pages/api/linking/[chain]/[address].ts
@@ -19,7 +19,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   }
   const ret: Record<string, AddressInfo[]> = {}
   for (const contractInfo of contracts) {
-    const addresses = getAddresses(contractInfo)
+    const addresses = await getAddresses(contractInfo)
     addresses.forEach((addressInfo) => {
       delete addressInfo.parent
     })

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -12,6 +12,7 @@ export declare interface AddressInfo {
   locEndCol: number
   rangeTo?: number
   rangeFrom?: number
+  getAddress?: (...args: any) => Promise<any>;
   source:
     | 'variable'
     | 'hardcoded'


### PR DESCRIPTION
Yep, quick and dirty within ~4 hours of time. Sorry for just a wall of code, mb i refactor it tomorrow if the time allows.

Other than that:

 should be working for variety of cases: 

 1. `InterfaceName(0x0000).function(varName, "string", 0x000)
 2. `InterfaceName(VARNAME).function(varName, "string", 0x000)
 3. `Libname.function(varName, "string", 0x000)

Pls try to break it.
I'll fix according to approach "less matches is a feature, extra matches is a bug" if perfect fix is not feasible.

I've tested with hand-crafted contracts and with https://etherscan.io/address/0x73603dB34814b22379CeD3d2Cbb450B3968Fd892#code