### PR TITLE
Hotfix mode library

### DIFF
--- a/app/src/helpers/getContractAddresses.ts
+++ b/app/src/helpers/getContractAddresses.ts
@@ -1,7 +1,7 @@
 import { Contract } from '@prisma/client';
 import { parse, visit } from '@solidity-parser/parser'
 import { ASTNode, BaseASTNode, VariableDeclaration } from '@solidity-parser/parser/dist/src/ast-types';
-import { AddressInfo } from '~/types'
+import { AddressInfo, SupportedChain } from '~/types'
 import loadContractLibraries from './loadContractLibraries';
 import getPrisma from './getPrisma';
 import {Contract as EthersContract, utils, providers} from 'ethers'
@@ -214,7 +214,7 @@ export const getAddresses = async (contractInfo: Contract) => {
       )
     }
   })
-  const loadedLibraries = await loadContractLibraries(address, chain);
+  const loadedLibraries = await loadContractLibraries(address, chain as SupportedChain);
   const monitoredFunctions: Record<string, string[]> = {};
   for (const [libraryName, libraryAddress] of Object.entries(loadedLibraries)) {
     const abi = (await getPrisma().contract.findFirst({

--- a/app/src/helpers/getContractInfo.ts
+++ b/app/src/helpers/getContractInfo.ts
@@ -45,7 +45,7 @@ export default async function getContractInfo(
         runs: Number(data.optimization_runs) ?? 0,
         constructorArguments: data.constructor_args ?? '',
         evmVersion: data.evm_version,
-        library: data.external_libraries.join(';') ?? '',
+        library: data.external_libraries.map((l: { name: string; address_hash: string }) => `${l.name}:${l.address_hash.slice(2)}`).join(';') ?? '',
         licenseType: '',
         proxy: data.minimal_proxy_address_hash ?? '',
         implementation: '',

--- a/app/src/helpers/getContractInfo.ts
+++ b/app/src/helpers/getContractInfo.ts
@@ -45,7 +45,7 @@ export default async function getContractInfo(
         runs: Number(data.optimization_runs) ?? 0,
         constructorArguments: data.constructor_args ?? '',
         evmVersion: data.evm_version,
-        library: JSON.stringify(data.external_libraries),
+        library: data.external_libraries.join(';') ?? '',
         licenseType: '',
         proxy: data.minimal_proxy_address_hash ?? '',
         implementation: '',

--- a/app/src/helpers/loadContractLibraries.ts
+++ b/app/src/helpers/loadContractLibraries.ts
@@ -1,7 +1,8 @@
+import { SupportedChain } from "~/types";
 import getContractInfo from "./getContractInfo";
 import getPrisma from "./getPrisma";
 
-export default async function loadContractLibraries(address: string, chain: string) {
+export default async function loadContractLibraries(address: string, chain: SupportedChain) {
   await getContractInfo(address, chain);
   const contract = await getPrisma().contract.findFirst({ where: {
     address,


### PR DESCRIPTION
- api response from https://sepolia.explorer.mode.network/api-docs regarding libraries is different from etherscan and was not handled correctly.

Etherscan returns `'Name:address-without-0x-in-front;Another-name:another_address`
The api above as per endpoint doc returns a dict of specific structure.
Pls evaluate the bugfix (i.e. read the api docs for the `smart-contracts/address` and see how the code adjustment covers for it.)